### PR TITLE
DASH charging + LED + clean-up non use binary

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -176,9 +176,9 @@ PRODUCT_PACKAGES += \
     qdcm_calib_data_samsung_s6e3fa5_1080p_cmd_mode_dsi_panel.xml
 
 # Fingerprint sensor
-PRODUCT_PACKAGES += \
-    fingerprintd \
-    OneplusPocketMode
+#PRODUCT_PACKAGES += \
+#    fingerprintd \
+#    OneplusPocketMode
 
 # For android_filesystem_config.h
 PRODUCT_PACKAGES += \

--- a/proprietary-files-qc.txt
+++ b/proprietary-files-qc.txt
@@ -387,7 +387,7 @@ vendor/qcril.db
 
 # Radio - IMS
 bin/ims_rtp_daemon
-bin/imscmservice
+#bin/imscmservice
 bin/imsdatadaemon
 bin/imsqmidaemon
 etc/permissions/imscm.xml

--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -718,6 +718,9 @@ service fstman /system/bin/fstman -B -ddd -c /data/misc/wifi/fstman.ini
     disabled
     oneshot
 
+
+
+
 # FST Manager with supplicant - connect to supplicant socket
 service fstman_wlan0 /system/bin/fstman -B -ddd -c /data/misc/wifi/fstman.ini @android:wpa_wlan0
     user wifi
@@ -1085,14 +1088,14 @@ on property:ro.logdumpd.enabled=1
 #    user root
 #    group root
 #    writepid /dev/cpuset/system-background/tasks
-    
+
 service init_wlan_bt /system/bin/sh /system/etc/init_wlan_bt.sh
     class main
     user root
     group root
     oneshot
-    
-    
+
+
 service minimedia /system/bin/minimediaservice
     class main
     user media
@@ -1100,7 +1103,7 @@ service minimedia /system/bin/minimediaservice
     ioprio rt 4
 #   hack to make recorded video playback work
     setenv LD_PRELOAD /system/lib/libOmxVdec.so
-    
+
 service miniafservice /system/bin/miniafservice
     class core
     user root

--- a/rootdir/etc/init.target.rc
+++ b/rootdir/etc/init.target.rc
@@ -148,17 +148,17 @@ on boot
     chmod 0664 /sys/class/graphics/fb0/dci_p3
 
     # Fingerprint
-    chmod 0664 /sys/devices/soc/soc:fpc_fpc1020/irq
+    chmod 0666 /sys/devices/soc/soc:fpc_fpc1020/irq
     chown system system /sys/devices/soc/soc:fpc_fpc1020/irq
-    chmod 0660 /sys/devices/soc/soc:fpc_fpc1020/report_home
+    chmod 0666 /sys/devices/soc/soc:fpc_fpc1020/report_home
     chown system system /sys/devices/soc/soc:fpc_fpc1020/report_home
-    chmod 0660 /sys/devices/soc/soc:fpc_fpc1020/update_info
+    chmod 0666 /sys/devices/soc/soc:fpc_fpc1020/update_info
     chown system system /sys/devices/soc/soc:fpc_fpc1020/update_info
-    chmod 0660 /sys/devices/soc/soc:fpc_fpc1020/screen_state
+    chmod 0666 /sys/devices/soc/soc:fpc_fpc1020/screen_state
     chown system system /sys/devices/soc/soc:fpc_fpc1020/screen_state
-    chmod 0660 /sys/devices/soc/soc:fpc_fpc1020/hw_reset
+    chmod 0666 /sys/devices/soc/soc:fpc_fpc1020/hw_reset
     chown system system /sys/devices/soc/soc:fpc_fpc1020/hw_reset
-    chmod 0660 /sys/devices/soc/soc:fpc_fpc1020/proximity_state
+    chmod 0666 /sys/devices/soc/soc:fpc_fpc1020/proximity_state
     chown system system /sys/devices/soc/soc:fpc_fpc1020/proximity_state
 
     # NFC
@@ -174,47 +174,62 @@ on boot
     chown system system /sys/class/leds/red/pause_lo
     chown system system /sys/class/leds/blue/pause_lo
     chown system system /sys/class/leds/green/pause_lo
+    chmod 0666 /sys/class/leds/red/pause_lo
+    chmod 0666 /sys/class/leds/blue/pause_lo
+    chmod 0666 /sys/class/leds/green/pause_lo
 
     chown system system /sys/class/leds/red/pause_hi
     chown system system /sys/class/leds/blue/pause_hi
     chown system system /sys/class/leds/green/pause_hi
+    chmod 0666 /sys/class/leds/red/pause_hi
+    chmod 0666 /sys/class/leds/blue/pause_hi
+    chmod 0666 /sys/class/leds/green/pause_hi
 
     chown system system /sys/class/leds/red/blink
     chown system system /sys/class/leds/blue/blink
     chown system system /sys/class/leds/green/blink
+    chmod 0666 /sys/class/leds/red/blink
+    chmod 0666 /sys/class/leds/blue/blink
+    chmod 0666 /sys/class/leds/green/blink
 
-    chown system system /sys/class/leds/red/blink
-    chown system system /sys/class/leds/blue/blink
-    chown system system /sys/class/leds/green/blink
+
     chown system system /sys/class/leds/red/ramp_step_ms
     chown system system /sys/class/leds/blue/ramp_step_ms
     chown system system /sys/class/leds/green/ramp_step_ms
+    chmod 0666 /sys/class/leds/red/ramp_step_ms
+    chmod 0666 /sys/class/leds/green/ramp_step_ms
+    chmod 0666 /sys/class/leds/blue/ramp_step_ms
+
     chown system system /sys/class/leds/red/duty_pcts
     chown system system /sys/class/leds/blue/duty_pcts
     chown system system /sys/class/leds/green/duty_pcts
+    chmod 0666 /sys/class/leds/red/duty_pcts
+    chmod 0666 /sys/class/leds/green/duty_pcts
+    chmod 0666 /sys/class/leds/blue/duty_pcts
+
     chown system system /sys/class/leds/red/start_idx
     chown system system /sys/class/leds/blue/start_idx
     chown system system /sys/class/leds/green/start_idx
+    chmod 0666 /sys/class/leds/red/start_idx
+    chmod 0666 /sys/class/leds/green/start_idx
+    chmod 0666 /sys/class/leds/blue/start_idx
+
+    chown system system /sys/class/leds/red/brightness
+    chown system system/sys/class/leds/green/brightness
+    chown system system /sys/class/leds/blue/brightness
+    chmod 0666 /sys/class/leds/red/brightness
+    chmod 0666 /sys/class/leds/green/brightness
+    chmod 0666 /sys/class/leds/blue/brightness
 
     chown system system /sys/class/leds/rgb/rgb_blink
-
-    chmod 660 /sys/class/leds/red/ramp_step_ms
-    chmod 660 /sys/class/leds/green/ramp_step_ms
-    chmod 660 /sys/class/leds/blue/ramp_step_ms
-    chmod 660 /sys/class/leds/red/duty_pcts
-    chmod 660 /sys/class/leds/green/duty_pcts
-    chmod 660 /sys/class/leds/blue/duty_pcts
-    chmod 660 /sys/class/leds/red/start_idx
-    chmod 660 /sys/class/leds/green/start_idx
-    chmod 660 /sys/class/leds/blue/start_idx
-    chmod 660 /sys/class/leds/rgb/rgb_blink
+    chmod 0666 /sys/class/leds/rgb/rgb_blink
 
     setprop persist.camera.HAL3.enabled 1
 
-    
+
     #Vibrator
     chmod 0666 /sys/class/timed_output/vibrator/enable
-    
+
     #LEDs
     chmod 0666 /sys/class/leds/red/blink
     chmod 0666 /sys/class/leds/red/brightness
@@ -222,7 +237,7 @@ on boot
     chmod 0666 /sys/class/leds/green/brightness
     chmod 0666 /sys/class/leds/blue/blink
     chmod 0666 /sys/class/leds/blue/brightness
-    
+
     #torch
     chmod 0666 /sys/class/leds/led:switch/brightness
     chmod 0666 /sys/class/leds/torch-light0/brightness

--- a/rootdir/etc/init.target.rc
+++ b/rootdir/etc/init.target.rc
@@ -238,11 +238,11 @@ service qcamerasvr /system/bin/mm-qcamera-daemon
     writepid /dev/cpuset/system-background/tasks
 
 #fingerprint service
-service fingerprintd /system/bin/fingerprintd
-    class late_start
-    user system
-    group system
-    writepid /dev/cpuset/system-background/tasks
+#service fingerprintd /system/bin/fingerprintd
+#    class late_start
+#    user system
+#    group system
+#    writepid /dev/cpuset/system-background/tasks
 
 service qfp-daemon /system/bin/qfp-daemon
     class late_start
@@ -497,7 +497,7 @@ service imscmservice /system/bin/imscmservice
 
 on property:sys.ims.DATA_DAEMON_STATUS=1
    start ims_rtp_daemon
-   start imscmservice
+#   start imscmservice
 
 service dts_configurator /system/bin/dts_configurator
     class late_start
@@ -570,6 +570,7 @@ on charger
     write /sys/module/lpm_levels/parameters/sleep_disabled 0
     wait /dev/block/bootdevice/by-name/system
     mount ext4 /dev/block/bootdevice/by-name/system /system ro barrier=1
+    # start hvdcp_opti
 
 service dhcpcd_eth0 /system/bin/dhcpcd -ABKLG
 	class late_start

--- a/rootdir/etc/init.target.rc
+++ b/rootdir/etc/init.target.rc
@@ -564,6 +564,15 @@ service mdtpd /system/vendor/bin/mdtpd
    group system radio drmrpc
    disabled
 
+   service dashd /sbin/dashd
+       class core
+       critical
+       seclabel u:r:dashd:s0
+       group root system
+
+   on property:init.svc.healthd=restarting
+       restart dashd
+
 on charger
     write /sys/devices/system/cpu/cpu2/online 0
     write /sys/devices/system/cpu/cpu3/online 0
@@ -571,6 +580,8 @@ on charger
     wait /dev/block/bootdevice/by-name/system
     mount ext4 /dev/block/bootdevice/by-name/system /system ro barrier=1
     # start hvdcp_opti
+    start dashd
+
 
 service dhcpcd_eth0 /system/bin/dhcpcd -ABKLG
 	class late_start

--- a/sepolicy/dashd.te
+++ b/sepolicy/dashd.te
@@ -14,6 +14,10 @@ binder_use(dashd)
 binder_service(dashd)
 binder_call(dashd, system_server)
 
+
+# Write to state file.
+allow dashd sysfs:file write;
+
 ###
 ### dashd: charger mode
 ###


### PR DESCRIPTION
Hello,

Please see enclose commits
- to enable DASH charging,
- to clean-up some unused binary, cleaning syslog. I've commented the fingerprintd binary as Ubuntu Touch will not use it, and bringing the reader to life will require to create a plugin like the Turbo device for biometryd.
- Enable led notification (Not sure while the LED is on ONLY when screen is OFF)
```

[  194.170020] FASTCHG: usb_sw_gpio_set: set usb_sw_gpio = 1
[  194.857110] SMBCHG: set_dash_charger_present: set dash online
[  194.857430] SMBCHG: set_chg_ibat_vbat_max: vote ibatmax = 1910 and set vbatmax = 4320
[  194.859298] SMBCHG: qpnp_battery_temp_region_set: set temp_region = 5
[  194.859331] SMBCHG: smbchg_external_power_changed: change usb_target_current_ma = 1800
[  194.859781] SMBCHG: smbchg_set_usb_current_max: USB current_ma = 1800, typeC_support_current_ma = 4000
[  194.861316] SMBCHG: smbchg_rerun_aicl: Rerunning AICL...
[  194.934908] dashd: dash read
```

![image](https://user-images.githubusercontent.com/11337464/70488153-6393e780-1abd-11ea-8493-ddf0cd413bb2.png)

@Vince1171 
