### PR TITLE
Dirty hack to allow wifi to restart

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -217,7 +217,7 @@
          Wifi interfaces.  If the device doesn't want to support tethering over Wifi this
          should be empty.  An example would be "softap.*" -->
     <string-array translatable="false" name="config_tether_wifi_regexs">
-        <item>"wlan0"</item>
+        <item>"wlp1s0"</item>
     </string-array>
 
     <!-- List of regexpressions describing the interface (if any) that represent tetherable

--- a/rootdir/etc/init_wlan_bt.sh
+++ b/rootdir/etc/init_wlan_bt.sh
@@ -9,7 +9,7 @@ rm /data/misc/wifi/WCNSS_qcom_wlan_nv.bin
 export LD_LIBRARY_PATH=/vendor/lib64:/system/lib64:/vendor/lib:/system/lib
 #logwrapper /system/bin/conn_init
 
-echo 1 > /dev/wcnss_wlan
+#echo 1 > /dev/wcnss_wlan
 
 enable_bt () {
 
@@ -29,10 +29,10 @@ while true; do
     sleep 2
     if [ ! -f /sys/devices/soc/600000.qcom,pcie/pci0000:00/0000:00:00.0/0000:01:00.0/net/wlp1s0/address ]; then
         echo sta > /sys/module/wlan/parameters/fwpath
-    else
+    #else
         # enable bluetooth here since we have to wait for wlan to be initialized
         #enable_bt
-        break
+        #break
     fi
 done
 

--- a/rootdir/etc/init_wlan_bt.sh
+++ b/rootdir/etc/init_wlan_bt.sh
@@ -29,6 +29,8 @@ while true; do
     sleep 2
     if [ ! -f /sys/devices/soc/600000.qcom,pcie/pci0000:00/0000:00:00.0/0000:01:00.0/net/wlp1s0/address ]; then
         echo sta > /sys/module/wlan/parameters/fwpath
+        sleep 60 #wait 1 min after the action, unlikely user will switch 0ff/on/off then on in a minute.
+        #TODO Look on dbus side to capture the wifi reactivation ?
     #else
         # enable bluetooth here since we have to wait for wlan to be initialized
         #enable_bt


### PR DESCRIPTION
I'm using the init._wlan_bt.sh as a watchdog to ensure fwpath is setup correctly. 

- Would be cleaner through the dbus
- Would be interesting to understand why fwpath requires that each time the wifi getting disable.

Fixing : https://github.com/ubports/ubuntu-touch/issues/1296

@Vince1171 