### PR TITLE
revert the acdb_ids, it might creates problems on some devices

### DIFF
--- a/audio/audio_platform_info.xml
+++ b/audio/audio_platform_info.xml
@@ -26,7 +26,6 @@
 <!-- IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                          -->
 <audio_platform_info>
     <acdb_ids>
-       <device name="SND_DEVICE_OUT_VOICE_SPEAKER" acdb_id="34"/>
 
     </acdb_ids>
     <backend_names>


### PR DESCRIPTION
It might create issue to some user, 
On my OP3, this setting allows to have a decent sound from the speaker in voice mode.

@Vince1171 