### PR TITLE
Improved wifi management

### DIFF
--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -473,6 +473,7 @@ on property:vold.decrypt=trigger_restart_framework
     start cnss_diag
 #       start config_bt_addr
 #    start config_bluetooth
+#    disabled
 
 on property:persist.env.fastdorm.enabled=true
     setprop persist.radio.data_no_toggle 1

--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -473,7 +473,7 @@ on property:vold.decrypt=trigger_restart_framework
     start cnss_diag
 #       start config_bt_addr
 #    start config_bluetooth
-#    disabled
+    disabled
 
 on property:persist.env.fastdorm.enabled=true
     setprop persist.radio.data_no_toggle 1

--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -473,7 +473,6 @@ on property:vold.decrypt=trigger_restart_framework
     start cnss_diag
 #       start config_bt_addr
 #    start config_bluetooth
-    disabled
 
 on property:persist.env.fastdorm.enabled=true
     setprop persist.radio.data_no_toggle 1

--- a/rootdir/etc/init_wlan_bt.sh
+++ b/rootdir/etc/init_wlan_bt.sh
@@ -1,21 +1,15 @@
 #!/system/bin/sh
-
 ## The Ubports project
-
-
 # Workaround for conn_init not copying the updated firmware
  rm /data/misc/wifi/WCNSS_qcom_cfg.ini
  rm /data/misc/wifi/WCNSS_qcom_wlan_nv.bin
 
-#Maximum number of attempts to enable hcismd to try to get
-# hci0 to come online.  Writing to sysfs too early seems to
-# not work, so we loop.
-MAXTRIES=2
-
+#Maximum number of attempts to enable wifi
+MAXTRIES=1
 export LD_LIBRARY_PATH=/vendor/lib64:/system/lib64:/vendor/lib:/system/lib
 
 #Wifi enabler
-j=1
+j=0
 while [ ! $j -gt $MAXTRIES ]  ; do
     #echo 1 > /dev/wcnss_wlan
     echo sta > /sys/module/wlan/parameters/fwpath
@@ -24,6 +18,4 @@ while [ ! $j -gt $MAXTRIES ]  ; do
       sleep 1
     fi
     j=$((j + 1))
-done
-
 done

--- a/ubuntu/70-oneplus3.rules
+++ b/ubuntu/70-oneplus3.rules
@@ -244,4 +244,6 @@ ACTION=="add", KERNEL=="ts0710mux*", OWNER="radio", GROUP="radio", MODE="0640"
 ACTION=="add", KERNEL=="ppp", OWNER="radio", GROUP="vpn", MODE="0660"
 ACTION=="add", KERNEL=="dvb*", OWNER="root", GROUP="system", MODE="0660"
 ACTION=="change", DEVPATH=="/devices/virtual/switch/tri-state-key", SUBSYSTEM=="switch", RUN+="/usr/bin/python3 /system/halium/usr/share/tri_state_switch/tri_state.py"
+# Force the name of the wifi device to avoid network-manager confusion
+SUBSYSTEM=="net", ACTION=="add", KERNEL=="*", SUBSYSTEMS=="*", KERNELS=="0000:01:00.0", NAME="wlp1s0"
 ACTION=="add|remove", SUBSYSTEM=="net", RUN+="/usr/bin/python3 /system/halium/usr/share/wlan_restart/wlan_restart.py"


### PR DESCRIPTION
Each time the wifi is restarted, after a fligth mode, the device name changes, confusing network-manager/nmcli. Thus it was likely that the reconnection was not possible or taking time to a known wifi network.
This commit enforce, than one of the wifi device has the same name each time. 

Ps: To be noticed that 2 wifi devices with 2 different mac address is found by nmcli. 

@Vince1171 