### PR TITLE
Clean-up some remaining deep_buffer options

### DIFF
--- a/audio/audio_policy_configuration.xml
+++ b/audio/audio_policy_configuration.xml
@@ -258,23 +258,23 @@
             <!-- route declaration, i.e. list all available sources for a given sink -->
             <routes>
                 <route type="mix" sink="Earpiece"
-                       sources="primary output,raw,deep_buffer,direct_pcm,compressed_offload,voip_rx"/>
+                       sources="primary output,raw,direct_pcm,compressed_offload,voip_rx"/>
                 <route type="mix" sink="Speaker"
-                       sources="primary output,raw,deep_buffer,direct_pcm,compressed_offload,voip_rx"/>
+                       sources="primary output,raw,direct_pcm,compressed_offload,voip_rx"/>
                 <route type="mix" sink="Wired Headset"
-                       sources="primary output,raw,deep_buffer,direct_pcm,compressed_offload,voip_rx"/>
+                       sources="primary output,raw,direct_pcm,compressed_offload,voip_rx"/>
                 <route type="mix" sink="Wired Headphones"
-                       sources="primary output,raw,deep_buffer,direct_pcm,compressed_offload,voip_rx"/>
+                       sources="primary output,raw,direct_pcm,compressed_offload,voip_rx"/>
                 <route type="mix" sink="Line"
-                       sources="primary output,raw,deep_buffer,direct_pcm,compressed_offload,voip_rx"/>
+                       sources="primary output,raw,direct_pcm,compressed_offload,voip_rx"/>
                 <route type="mix" sink="HDMI"
-                       sources="primary output,raw,deep_buffer,multichannel,direct_pcm,compressed_offload"/>
+                       sources="primary output,raw,multichannel,direct_pcm,compressed_offload"/>
                 <route type="mix" sink="Proxy"
-                       sources="primary output,raw,deep_buffer,multichannel,direct_pcm,compressed_offload"/>
+                       sources="primary output,raw,multichannel,direct_pcm,compressed_offload"/>
                 <route type="mix" sink="FM"
                        sources="primary output"/>
                 <route type="mix" sink="BT SCO All"
-                       sources="primary output,raw,deep_buffer,direct_pcm,compressed_offload,voip_rx"/>
+                       sources="primary output,raw,direct_pcm,compressed_offload,voip_rx"/>
                 <route type="mix" sink="Telephony Tx"
                        sources="voice_tx"/>
                 <route type="mix" sink="primary input"

--- a/rootdir/etc/init_wlan_bt.sh
+++ b/rootdir/etc/init_wlan_bt.sh
@@ -4,18 +4,9 @@
  rm /data/misc/wifi/WCNSS_qcom_cfg.ini
  rm /data/misc/wifi/WCNSS_qcom_wlan_nv.bin
 
-#Maximum number of attempts to enable wifi
-MAXTRIES=1
+
+
 export LD_LIBRARY_PATH=/vendor/lib64:/system/lib64:/vendor/lib:/system/lib
 
-#Wifi enabler
-j=0
-while [ ! $j -gt $MAXTRIES ]  ; do
-    #echo 1 > /dev/wcnss_wlan
-    echo sta > /sys/module/wlan/parameters/fwpath
-    echo "wlan : activated"
-    if [ "$?" -ne "0" ]; then
-      sleep 1
-    fi
-    j=$((j + 1))
-done
+echo sta > /sys/module/wlan/parameters/fwpath
+echo "wlan : activated"

--- a/system.prop
+++ b/system.prop
@@ -122,20 +122,6 @@ wifi.interface=wlp1s0
 # Mir
 ro.build.qti_bsp.abi=1
 
-# qualcomm sensors enable https://github.com/audahadi/android_device_xiaomi_cancro/commit/e71d6df2abce713313b6c447643e1b88d0f8c888
-#ro.qualcomm.sensors.qmd=true
-#ro.qualcomm.sensors.smd=true
-#ro.qc.sdk.sensors.gestures=true
-#ro.qualcomm.sensors.pedometer=true
-#ro.qualcomm.sensors.pam=true
-#ro.qualcomm.sensors.scrn_ortn=true
-#ro.qc.sensors.step_detector=true
-#ro.qc.sensors.step_counter=true
-#ro.qualcomm.sensors.georv=true
-#debug.qualcomm.sns.hal=w
-#debug.qualcomm.sns.daemon=w
-#debug.qualcomm.sns.libsensor1=w
-#ro.qc.sensors.wl_dis=true
 
 # HDMI out
 com.qc.hardware=true

--- a/ubuntu/70-oneplus3.rules
+++ b/ubuntu/70-oneplus3.rules
@@ -244,6 +244,4 @@ ACTION=="add", KERNEL=="ts0710mux*", OWNER="radio", GROUP="radio", MODE="0640"
 ACTION=="add", KERNEL=="ppp", OWNER="radio", GROUP="vpn", MODE="0660"
 ACTION=="add", KERNEL=="dvb*", OWNER="root", GROUP="system", MODE="0660"
 ACTION=="change", DEVPATH=="/devices/virtual/switch/tri-state-key", SUBSYSTEM=="switch", RUN+="/usr/bin/python3 /system/halium/usr/share/tri_state_switch/tri_state.py"
-# Force the name of the wifi device to avoid network-manager confusion
-SUBSYSTEM=="net", ACTION=="add", KERNEL=="*", SUBSYSTEMS=="*", KERNELS=="0000:01:00.0", NAME="wlp1s0"
-ACTION=="add|remove", SUBSYSTEM=="net", RUN+="/usr/bin/python3 /system/halium/usr/share/wlan_restart/wlan_restart.py"
+ACTION=="change|remove|create", DEVPATH=="/devices/soc/600000.qcom,pcie/pci0000:00/0000:00:00.0/0000:01:00.0/ieee80211/phy?", RUN+="/usr/bin/python3 /system/halium/usr/share/wlan_restart/wlan_restart.py"

--- a/ubuntu/base
+++ b/ubuntu/base
@@ -186,7 +186,7 @@
 
   # Workaround https://launchpad.net/bugs/359338 until upstream handles stacked
   # filesystems generally. This does not appreciably decrease security with
-  # Ubuntu profiles because the user is exp                                                                           ected to have access to files owned
+  # Ubuntu profiles because the user is expected to have access to files owned
   # by him/her. Exceptions to this are explicit in the profiles. While this rule
   # grants access to those exceptions, the intended privacy is maintained due to
   # the encrypted contents of the files in this directory. Files in this
@@ -197,4 +197,10 @@
   # encrypted ~/.Private and old-style encrypted $HOME
   owner @{HOME}/.Private/** mrixwlk,
   # new-style encrypted $HOME
-owner @{HOMEDIRS}/.ecryptfs/*/.Private/** mrixwlk,
+  owner @{HOMEDIRS}/.ecryptfs/*/.Private/** mrixwlk,
+
+  # media_codecs
+  /{android/,}system/etc/media_codecs_performance.xml      r,
+  /{android/,}system/etc/media_codecs_google_audio.xml     r,
+  /{android/,}system/etc/media_codecs_google_telephony.xml r,
+  /{android/,}system/etc/media_codecs_google_video.xml     r,

--- a/ubuntu/wlan_restart.py
+++ b/ubuntu/wlan_restart.py
@@ -2,10 +2,5 @@
 import subprocess
 import os.path
 
-content_file = '/sys/devices/soc/600000.qcom,pcie/pci0000:00/0000:00:00.0/0000:01:00.0/net/wlp1s0/address'
-
-if os.path.isfile(content_file) :
-    print("Wlan already activated")
-else:
-    subprocess.Popen("echo sta > /sys/module/wlan/parameters/fwpath", shell=True)
-    print("Wifi card set up for wlan activation")
+subprocess.Popen("echo sta > /sys/module/wlan/parameters/fwpath", shell=True)
+print("Wifi card set up")


### PR DESCRIPTION
clean up un-necessary code for the wlan activation and restart
clena up system.prop of commented lines
add some reading authorisation on codect file (take from other ports)
Update udev rules to avoid a race condition at the boot.

Will fix the race condition https://github.com/ubports/ubuntu-touch/issues/1396
Thanks to peat-psuwit for the finding.